### PR TITLE
Fix bug for fork sync action

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -20,7 +20,8 @@ jobs:
           upstream_sync_repo: LovesAsuna/ForumSignin
           upstream_sync_branch: master
           target_sync_branch: master
-          git_pull_args: '-s recursive -Xtheirs'
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          upstream_pull_args: '-s recursive -Xtheirs'
 
       - uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
# Fix some bugs for using action 'aormsby/Fork-Sync-With-Upstream-action'
- git_pull_args is invalid args according to the action `aormsby/Fork-Sync-With-Upstream-action` readme.
- target_repo_token is required to push data to target repository.